### PR TITLE
fix: type checker

### DIFF
--- a/language/bert/quantization/calibrate.py
+++ b/language/bert/quantization/calibrate.py
@@ -78,7 +78,7 @@ def get_args():
     parser.add_argument("--model_config_path", help="path to bert model config")
     parser.add_argument("--quant_config_path", help="a config for model quantization")
     parser.add_argument(
-        "--quant_param_path", help="quantization parameters for calibraed layers"
+        "--quant_param_path", help="quantization parameters for calibrated layers"
     )
     parser.add_argument(
         "--quant_format_path", help="quantization specifications for calibrated layers"
@@ -90,7 +90,7 @@ def get_args():
     parser.add_argument(
         "--torch_numeric_optim",
         action="store_true",
-        help="use Pytorch numerical optimizaiton for CUDA/cudnn",
+        help="use PyTorch numerical optimizaiton for CUDA/cuDNN",
     )
     parser.add_argument(
         "--gpu", action="store_true", help="use GPU instead of CPU for the inference"
@@ -106,7 +106,7 @@ def main():
     if args.backend == "pytorch":
         if not args.gpu:
             raise ValueError(
-                "Inference on a device other than GPU is not suppurted yet."
+                "Inference on a device other than GPU is not supported yet."
             )
         model = load_pytorch_model(args.model_path, args.model_config_path, args.gpu)
 

--- a/language/bert/quantization/utils.py
+++ b/language/bert/quantization/utils.py
@@ -33,5 +33,5 @@ def get_kwargs(fn, config_dict: Mapping[str, Any]):
     return {
         k: v
         for k, v in config_dict.items()
-        if k in params and params[k].annotation == Optional[type(v)]
+        if k in params and isinstance(v, params[k].annotation)
     }

--- a/language/bert/run.py
+++ b/language/bert/run.py
@@ -52,10 +52,10 @@ def get_args():
     parser.add_argument('--sut_server', nargs="*", default= ['http://localhost:8000'],
                     help='Address of the server(s) under test.')
     parser.add_argument("--quant_config_path", help="a config for model quantization")
-    parser.add_argument("--quant_param_path", help="quantization parameters for calibraed layers")
+    parser.add_argument("--quant_param_path", help="quantization parameters for calibrated layers")
     parser.add_argument("--quant_format_path", help="quantization specifications for calibrated layers")
-    parser.add_argument("--quantize", action="store_true", help="quantize model using ModelComPressor(MCP)")
-    parser.add_argument('--torch_numeric_optim', action="store_true", help="use Pytorch numerical optimizaiton for CUDA/cudnn")
+    parser.add_argument("--quantize", action="store_true", help="quantize model using Model Compressor")
+    parser.add_argument('--torch_numeric_optim', action="store_true", help="use PyTorch numerical optimizaiton for CUDA/cuDNN")
     parser.add_argument("--gpu", action="store_true", help="use GPU instead of CPU for the inference")
     args = parser.parse_args()
     return args
@@ -109,7 +109,7 @@ def main():
 
         if not args.gpu:
             raise ValueError(
-                "Inference on a device other than GPU is not suppurted yet."
+                "Inference on a device other than GPU is not supported yet."
             )
 
         sut.model = quantize_model(sut.model, args.quant_config_path,


### PR DESCRIPTION
https://github.com/furiosa-ai/inference/pull/20/commits/b28c36fd0a144225913a4c891ba33e6f1c867e5d 에서 `calibrate=True` 로 전체 데이터셋 10,833 에 대하여 평가한 결과는 아래와 같습니다. 이 결과는 가장 최근에 양자화 정확도를 확인한 https://github.com/furiosa-ai/inference/pull/12/commits/bdf0550ef18a09c98502a9de4edde2d6533fdb0b 에서의 f1 score 와 일치합니다. `NVIDIA RTX A6000` 에서 실행하여서, 이미 보고된 f1 score 값과 [91.05864237161231] 차이는 있습니다.(https://github.com/deeplearningfromscratch/inference/blob/mlperf-qbert/README.md?plain=1#L28C12-L28C29)
```
{"exact_match": 83.81267738883633, "f1": 91.02606927828413}
Reading examples...
Loading cached features from 'eval_features.pickle'...
Loading LoadGen logs...
Post-processing predictions...
Writing predictions to: /home/furiosa/workspace/jason/inference/logs/qbert/Offline/20240430_200459KST/predictions.json
Evaluating predictions...
```