### PR TITLE
Rewrite `QuantPreTrainedModel`

### DIFF
--- a/language/gpt-j/quantization/__init__.py
+++ b/language/gpt-j/quantization/__init__.py
@@ -51,7 +51,9 @@ class QuantizedGPTJForCausalLM(GPTJForCausalLM):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
-        arguments = {k: v for k, v in locals().items() if k != "self"}
+        arguments = locals()
+
+        del arguments["self"]
 
         for arg in self.__concrete_args:
             if arguments[arg] != self.__concrete_args[arg]:

--- a/language/gpt-j/quantization/__init__.py
+++ b/language/gpt-j/quantization/__init__.py
@@ -1,17 +1,14 @@
-import inspect
-from typing import Dict, Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import torch
 import yaml
+from transformers import GPTJForCausalLM
 from transformers.modeling_outputs import CausalLMOutputWithPast
-from transformers.modeling_utils import PreTrainedModel
 
 import model_compressor  # isort:skip
 
 from .custom_symbolic_trace import custom_symbolic_trace  # isort:skip
 from .utils import get_kwargs  # isort:skip
-
-SUPPORTED_CAUSAL_LM_ARCHITECTURES = ["GPTJForCausalLM"]
 
 
 def quantize_model(model, qconfig_path, qparam_path, qformat_path):
@@ -20,7 +17,7 @@ def quantize_model(model, qconfig_path, qparam_path, qformat_path):
 
     model, _, concrete_args = custom_symbolic_trace(model)
 
-    model = model_compressor.create_quantsim_model(
+    quantized_model = model_compressor.create_quantsim_model(
         model,
         qformat_path=qformat_path,
         qparam_path=qparam_path,
@@ -28,76 +25,46 @@ def quantize_model(model, qconfig_path, qparam_path, qformat_path):
         **get_kwargs(model_compressor.create_quantsim_model, qconfig),
     )
 
-    return build_causal_lm_for_graphmodule(
-        graph_module=model,
-        concrete_args=concrete_args,
-    )
+    return QuantizedGPTJForCausalLM(quantized_model, concrete_args)
 
 
-def build_causal_lm_for_graphmodule(
-    graph_module: torch.fx.GraphModule, concrete_args: Dict
-) -> PreTrainedModel:
-    parent_class: PreTrainedModel = graph_module.class_for_deserialization
+class QuantizedGPTJForCausalLM(GPTJForCausalLM):
+    def __init__(self, quantized_model, concrete_args):
+        super().__init__(quantized_model.config)
+        self.__quantized_model = quantized_model
+        self.__concrete_args = concrete_args
 
-    if parent_class.__name__ not in SUPPORTED_CAUSAL_LM_ARCHITECTURES:
-        raise ValueError(
-            f"Unsupported Huggingface Transformers architecture: {parent_class.__name__}."
-        )
+    # https://huggingface.co/docs/transformers/en/model_doc/gptj#transformers.GPTJForCausalLM.forward
+    # https://github.com/huggingface/transformers/blob/v4.40.1/src/transformers/models/gptj/modeling_gptj.py#L1104-L1118
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None,
+        attention_mask: Optional[torch.FloatTensor] = None,
+        token_type_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+    ) -> Union[Tuple, CausalLMOutputWithPast]:
+        arguments = {k: v for k, v in locals().items() if k != "self"}
 
-    gm_forward = graph_module.forward
-    sig_params = inspect.signature(gm_forward).parameters
-    forward_input_names = [param.name for param in sig_params.values()]
-    device = graph_module.device
+        for arg in self.__concrete_args:
+            if arguments[arg] != self.__concrete_args[arg]:
+                raise AssertionError(
+                    f"{arg}: {arguments[arg]} != {self.__concrete_args[arg]}"
+                )
+            del arguments[arg]
 
-    class GraphMouduleCausalForLM(parent_class):
-        def __init__(self, config):
-            super().__init__(config)
-            self.init_past_key_values = [
-                [torch.zeros(0).to(device), torch.zeros(0).to(device)]
-            ] * self.config.n_layer
+        if past_key_values is None:
+            arguments["past_key_values"] = (
+                (torch.zeros(0, device=self.__quantized_model.device),) * 2,
+            ) * self.__quantized_model.config.n_layer
 
-        def forward(
-            self,
-            input_ids: Optional[torch.LongTensor] = None,
-            past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None,
-            attention_mask: Optional[torch.FloatTensor] = None,
-            token_type_ids: Optional[torch.LongTensor] = None,
-            position_ids: Optional[torch.LongTensor] = None,
-            head_mask: Optional[torch.FloatTensor] = None,
-            inputs_embeds: Optional[torch.FloatTensor] = None,
-            use_cache: Optional[bool] = None,
-            output_attentions: Optional[bool] = None,
-            output_hidden_states: Optional[bool] = None,
-            return_dict: Optional[bool] = None,
-            **kwargs,
-        ):
-            if past_key_values is None:
-                past_key_values = self.init_past_key_values
+        outputs = self.__quantized_model.forward(**arguments)
 
-            forward_locals = locals()
-
-            def _validate_input_arg(key):
-                value = forward_locals[key]
-                if value != concrete_args[key]:
-                    raise ValueError(
-                        f"The Custom Tracer has set '{key}' as {concrete_args[key]}, "
-                        "but it's set as {value} during the forward pass. Please review the argument."
-                    )
-
-            _validate_input_arg("return_dict")
-            _validate_input_arg("use_cache")
-            _validate_input_arg("output_attentions")
-            _validate_input_arg("output_hidden_states")
-
-            forward_kwargs = {
-                name: forward_locals[name] for name in forward_input_names
-            }
-
-            outputs = gm_forward(**forward_kwargs)
-
-            if not return_dict:
-                return outputs
-
-            return CausalLMOutputWithPast(outputs)
-
-    return GraphMouduleCausalForLM(config=graph_module.config)
+        return CausalLMOutputWithPast(outputs) if return_dict else outputs


### PR DESCRIPTION
Fixes LLM-217

- `QuantPretrainedModel` 은 별다른 설명이 없으면 `PretrainedModel` 을 양자화와 관련이 있는 처리를 해주는 것으로 보일 수 있습니다.
  - 실제로는 양자화 결과물인 `torch.fx.GraphModule` 을 실행해주는 실행기로서 `forward` 를 제외하고 나머지 구성은 `xxCausalForLM` 와 동일합니다. 
  - 따라서, `GraphMouduleCausalForLM` 으로 다시 이름지었습니다.
- `transformers.PretrainedModel` 대신에 직접 부모 클래스(즉, GPTJCausalForLM) 를 상속 받도록하여 중복하여 구현되어 있는 instance method (`_validate_model_kwargs`, `prepare_inputs_for_generation`, `_reorder_cache`) 를 사용하지 않도록 했습니다.
- `torch.fx.GraphModule` 을 `__call__` 을 직접 호출하여 실행하는 대신 `model.forward` 에서 안정적으로 실행되도록 변경했습니다.
- `GraphModule` 에서 직접 가져올 수 있는 변수들(`model_type`, `input_names`) 은 더이상 class 인자로 받지 않습니다.
- `GraphModule.forward` 의 인자를 직접 가져와서 `forward_kwargs` 를 구성하여 모델 추론하도록 했으며, 이외 설정 입력들(`use_cache` 등) validate 로직과 분리했습니다.
  - 사실, concrete_args 는 `model.generate` 에 개입해서 설정해주는 값이 아니라 "만약 사용자가 `model.generate` 실행 시 해당되는 값들을 잘 못 넣어준다면 runtime 시 체크해서 오류가 있으니 다시 넣어달라" 는 개념에 가깝습니다.
  - 이 PR 에서는 그러한 변수를 최소화 시키긴 했습니다만, 이 부분도 아래 bullet 에서 서술한 것과 마찬가지 방법으로 수정이 필요하다고 생각합니다.
- runtime 에 알 수 있는 forward pass argument 들을 처리하는 로직이 `model.forward` 안에 구현이 되어 있어서 차후에 dynamo tracing 이 가능할지 확인이 필요합니다. 
  - 이 부분은 현재 `model.generate` 를 사용하는 대신 furiosa-llm-models 의 `Generator` 로 대체된다고 하면 처리 로직을 `model.forward` 밖에 둠으로써 해결 할 수 있을 것으로 예상합니다. 
  - 만약 그렇지 않다면, `model.generate` 를 수정해야 합니다.