### PR TITLE
qbert v3.12.1 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install libgl1 libglib2
 
 ### Wi8Ai8KVi8 Quantized BERT (qBERT)
 
-- Evaluation Result(v3.11)
+- Evaluation Result(v3.12.1)
 
     |    |                Our Result               |                                                                    Accuracy Target                                                                    |
     |:--:|:---------------------------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------:|

--- a/language/bert/RNGD_SUT.py
+++ b/language/bert/RNGD_SUT.py
@@ -78,7 +78,6 @@ class BERT_RNGD_SUT(BERT_PyTorch_SUT):
             traced_model = self.model.trace()
             self.model = quantize_model(
                 traced_model,
-                args.quant_config_path,
                 args.quant_param_path,
                 args.quant_format_path,
             )

--- a/language/bert/quantization/quantize.py
+++ b/language/bert/quantization/quantize.py
@@ -5,6 +5,8 @@ import model_compressor  # isort:skip
 
 from quantization.utils import get_kwargs  # isort:skip
 
+TARGET_MACHINE = 'RGDA0'
+QLEVEL = 4
 
 def quantize_model(
     model: GraphModule, qparam_path: str, qformat_path: str
@@ -16,6 +18,6 @@ def quantize_model(
         model,
         qformat_path=qformat_path,
         qparam_path=qparam_path,
-        target_machine='RGDA0',
-        qlevel=4,
+        target_machine=TARGET_MACHINE,
+        qlevel=QLEVEL,
     )

--- a/language/bert/quantization/quantize.py
+++ b/language/bert/quantization/quantize.py
@@ -7,16 +7,15 @@ from quantization.utils import get_kwargs  # isort:skip
 
 
 def quantize_model(
-    model: GraphModule, qconfig_path: str, qparam_path: str, qformat_path: str
+    model: GraphModule, qparam_path: str, qformat_path: str
 ) -> GraphModule:
-    with open(qconfig_path, "r") as f:
-        qconfig = yaml.safe_load(f)
+
     model.config.use_cache = False
 
     return model_compressor.create_quantsim_model(
         model,
         qformat_path=qformat_path,
         qparam_path=qparam_path,
-        disable_inout=(True, True),
-        **get_kwargs(model_compressor.create_quantsim_model, qconfig)
+        target_machine='RGDA0',
+        qlevel=4,
     )

--- a/language/bert/run.py
+++ b/language/bert/run.py
@@ -51,7 +51,6 @@ def get_args():
     parser.add_argument('--port', type=int, default=8000)
     parser.add_argument('--sut_server', nargs="*", default= ['http://localhost:8000'],
                     help='Address of the server(s) under test.')
-    parser.add_argument("--quant_config_path", help="a config for model quantization")
     parser.add_argument("--quant_param_path", help="quantization parameters for calibrated layers")
     parser.add_argument("--quant_format_path", help="quantization specifications for calibrated layers")
     parser.add_argument("--quantize", action="store_true", help="quantize model using Model Compressor")

--- a/logs/internal/qbert.dvc
+++ b/logs/internal/qbert.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 4354ff9c023e13419c84cd66fc8c466c.dir
-  size: 462556376
+- md5: 068a8d8b3571c97ce778687f495a9b82.dir
+  size: 214009317
   nfiles: 9
   hash: md5
   path: qbert

--- a/scripts/envs/qbert_env.yml
+++ b/scripts/envs/qbert_env.yml
@@ -8,7 +8,7 @@ dependencies:
       - torch==2.1.0+cu118
       - transformers==4.31.0
       - numpy==1.24.4
-      - git+https://github.com/furiosa-ai/furiosa-llm-models.git@MLPerf4.1-v3.11
-      - git+https://github.com/furiosa-ai/model-compressor-private.git@MLPerf4.1-v3.11
+      - git+https://github.com/furiosa-ai/furiosa-llm-models.git@MLPerf4.1-v3.12.1
+      - git+https://github.com/furiosa-ai/model-compressor-private.git@MLPerf4.1-v3.12.1
       - absl-py==2.1.0 
       - tokenization==1.0.7

--- a/scripts/eval_qbert.sh
+++ b/scripts/eval_qbert.sh
@@ -74,7 +74,6 @@ python -m run --scenario=$SCENARIO \
               --backend=$BACKEND \
               --gpu \
               --quantize \
-              --quant_config_path=$QUANT_CONFIG_PATH \
               --quant_param_path=$QUANT_PARAM_PATH \
               --quant_format_path=$QUANT_FORMAT_PATH \
               --max_examples=$N_COUNT \


### PR DESCRIPTION
- BERT 최신 release 인 v3.12.1 로 업데이트 PR 입니다.
- [v3.12.1 변경 사항 반영](https://furiosa-ai.slack.com/archives/C03PPKEGYUC/p1719936852961039?thread_ts=1719925908.063879&cid=C03PPKEGYUC):qformat, qparam 을 입력해서 model_compressor.create_quantsim_model() 을 사용하는 경우  disable_inout 을 포함해서 무시되는 argument 들이 입력되는 경우 warning 이 되도록 변경되었습니다. 이에 따라 evaluation 시에는 target_machine 과 qlevel 만 입력되게 변경하고 quant_config 를 불필요하게 입력받지 않도록 변경했습니다.
- v3.12.1 accuracy 는 [v3.11](https://github.com/furiosa-ai/inference/pull/27) 과 동일한 값이 나오는 것을 아래와 같이 확인했습니다. 

```
Evaluating predictions...
{"exact_match": 83.84105960264901, "f1": 91.05631631816962}
```