### PR TITLE
qgptj v3.12.1 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install libgl1 libglib2
 
 ### Wi8Ai8KVi8 Quantized BERT (qBERT)
 
-- Evaluation Result(v3.11)
+- Evaluation Result(v3.12.1)
 
     |    |                Our Result               |                                                                    Accuracy Target                                                                    |
     |:--:|:---------------------------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------:|
@@ -43,14 +43,14 @@ For evaluations with different settings, modify the following environment variab
 
 ### Wi8Ai8KVi8 Quantized GPT-J (qGPT-J)
 
-- Evaluation Result(v3.11)
+- Evaluation Result(v3.12.1)
 
     |         | Our Result                | Accuracy Target |
     |:-------:|:-------------------------:|:---------------:|
-    | ROUGE1  | 43.0453 (100.14%)         | [42.9865](https://github.com/mlcommons/inference/blob/e39003a9c4c89a2215db0ca57ad7a57b16f9a785/tools/submission/submission_checker.py#L1126C38-L1126C45) |
-    | ROUGE2  | 20.1418 (100.09%)         | [20.1235](https://github.com/mlcommons/inference/blob/e39003a9c4c89a2215db0ca57ad7a57b16f9a785/tools/submission/submission_checker.py#L1126C65-L1126C72) |
-    | ROUGEL  | 30.0315 (100.14%)         | [29.9881](https://github.com/mlcommons/inference/blob/e39003a9c4c89a2215db0ca57ad7a57b16f9a785/tools/submission/submission_checker.py#L1126C92-L1126C99) |
-    | GEN_LEN | 3,976,403 (98.99%)        | [4,016,878](https://github.com/mlcommons/inference/blob/e39003a9c4c89a2215db0ca57ad7a57b16f9a785/tools/submission/submission_checker.py#L1126C120-L1126C127) |
+    | ROUGE1  | 43.0305 (100.10%)         | [42.9865](https://github.com/mlcommons/inference/blob/e39003a9c4c89a2215db0ca57ad7a57b16f9a785/tools/submission/submission_checker.py#L1126C38-L1126C45) |
+    | ROUGE2  | 20.1437 (100.10%)         | [20.1235](https://github.com/mlcommons/inference/blob/e39003a9c4c89a2215db0ca57ad7a57b16f9a785/tools/submission/submission_checker.py#L1126C65-L1126C72) |
+    | ROUGEL  | 30.0211 (100.11%)         | [29.9881](https://github.com/mlcommons/inference/blob/e39003a9c4c89a2215db0ca57ad7a57b16f9a785/tools/submission/submission_checker.py#L1126C92-L1126C99) |
+    | GEN_LEN | 3,978,315 (99.04%)        | [4,016,878](https://github.com/mlcommons/inference/blob/e39003a9c4c89a2215db0ca57ad7a57b16f9a785/tools/submission/submission_checker.py#L1126C120-L1126C127) |
     
     - reference: [v3.11 Quantized GPT-J evaluation report](https://www.notion.so/furiosa/hugginface_rope_rngd_gelu-061729cc2bdc4410a9dd078fa05a317d)
 

--- a/data/quantization/gpt-j.dvc
+++ b/data/quantization/gpt-j.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 52a42b94e7cbdba03e2c0173aef4993b.dir
-  size: 11373618
+- md5: bdd4495238c41bbdc4115ab304760192.dir
+  size: 11608232
   nfiles: 3
   hash: md5
   path: gpt-j

--- a/language/gpt-j/backend_RNGD.py
+++ b/language/gpt-j/backend_RNGD.py
@@ -195,7 +195,7 @@ class SUT_base(PyTorch_SUT_base):
                     "Inference on a device other than GPU is not supported yet."
                 )
             traced_model = self.model.trace_all()
-            model= quantize_model(traced_model, qconfig_path=args.quant_config_path, qparam_path=args.quant_param_path, qformat_path=args.quant_format_path)
+            model= quantize_model(traced_model, qparam_path=args.quant_param_path, qformat_path=args.quant_format_path)
             self.kv_dtype = QUANT_KV_DTYPE
         else:
             model = self.model.trace_all()

--- a/language/gpt-j/dataset.py
+++ b/language/gpt-j/dataset.py
@@ -27,7 +27,7 @@ PROMPT_DICT = {
 
 
 class Dataset():
-    def __init__(self, dataset_path, batch_size=1, pad_val=1, pad_max=196, total_count_override=None, perf_count_override=None, num_splits=1, split_idx=0):
+    def __init__(self, dataset_path, batch_size=1, pad_val=1, pad_max=196, total_count_override=None, perf_count_override=None):
         print("Constructing QSL")
 
         self.dataset = "cnn_dailymail"
@@ -41,12 +41,7 @@ class Dataset():
         self.tokenizer.pad_token = self.tokenizer.eos_token
 
         self.list_data_dict = jload(self.dataset_path)
-        if num_splits > 1:
-            n_splited_data = int(len(self.list_data_dict)/num_splits)
-            start_idx = split_idx*n_splited_data
-            end_idx= (split_idx+1)*n_splited_data if split_idx!=num_splits-1 else len(self.list_data_dict) + 1
-            self.list_data_dict = self.list_data_dict[start_idx:end_idx]
-
+       
         prompt_input, prompt_no_input = PROMPT_DICT["prompt_input"], PROMPT_DICT["prompt_no_input"]
         self.sources = [prompt_input.format_map(
             example) for example in self.list_data_dict]

--- a/language/gpt-j/main.py
+++ b/language/gpt-j/main.py
@@ -42,8 +42,7 @@ def get_args():
     parser.add_argument('--port', type=int, default=8000)
     parser.add_argument('--sut_server', nargs="*", default= ['http://localhost:8000'],
                     help='Address of the server(s) under test.')
-    parser.add_argument("--quant_config_path", help="a config for model quantization")
-    parser.add_argument("--quant_param_path", help="quantization parameters for calibrated layers")
+    parser.add_argument("--quant_param_path", help="quantization parameters for calibrated layers") 
     parser.add_argument("--quant_format_path", help="quantization specifications for calibrated layers")
     parser.add_argument("--quantize", action="store_true", help="quantize model using Model Compressor")
     parser.add_argument('--torch_numeric_optim', action="store_true", help="use PyTorch numerical optimizaiton for CUDA/cuDNN")

--- a/language/gpt-j/quantization/quantize.py
+++ b/language/gpt-j/quantization/quantize.py
@@ -7,6 +7,9 @@ import model_compressor  # isort:skip
 from .utils import get_kwargs  # isort:skip
 
 
+TARGET_MACHINE = 'RGDA0'
+QLEVEL = 4
+
 def _quantize(
     model: GraphModule,
     qparam_path: str,
@@ -20,8 +23,8 @@ def _quantize(
         delete_org_weight=True,
         decode_phase=quantized_prefill is not None,
         quantized_prefill_model=quantized_prefill,
-        target_machine='RGDA0',
-        qlevel=4,
+        target_machine=TARGET_MACHINE,
+        qlevel=QLEVEL,
     )
 
 

--- a/scripts/envs/qgpt-j_env.yml
+++ b/scripts/envs/qgpt-j_env.yml
@@ -12,6 +12,6 @@ dependencies:
       - evaluate==0.4.1
       - absl-py==2.1.0
       - rouge_score==0.1.2
-      - git+https://github.com/furiosa-ai/furiosa-llm-models.git@MLPerf4.1-v3.11
-      - git+https://github.com/furiosa-ai/model-compressor-private.git@MLPerf4.1-v3.11
+      - git+https://github.com/furiosa-ai/furiosa-llm-models.git@MLPerf4.1-v3.12.1
+      - git+https://github.com/furiosa-ai/model-compressor-private.git@MLPerf4.1-v3.12.1
       - accelerate==0.31.0

--- a/scripts/eval_qgpt-j.sh
+++ b/scripts/eval_qgpt-j.sh
@@ -70,7 +70,6 @@ python -m main --scenario=$SCENARIO \
                --dataset-path=$DATASET_PATH \
                --gpu \
                --quantize \
-               --quant_config_path=$QUANT_CONFIG_PATH \
                --quant_param_path=$QUANT_PARAM_PATH \
                --quant_format_path=$QUANT_FORMAT_PATH \
                --max_examples=$N_COUNT \


### PR DESCRIPTION
- GPT-J 최신 release 인 v3.12.1 로 업데이트 PR 입니다.
- #31 과 동일하게 evaluation 시에는 target_machine 과 qlevel 을 hard coding 으로 두고 quant_config 를 불필요하게 입력받지 않도록 변경했습니다.
- 100 samples accuracy 확인 결과 inference-compression release 에서 확인한 [100 sample 결과](https://www.notion.so/furiosa/MLPerf4-1-v3-12-5bebd974a1a04275b57209cb3bd3e9d8?pvs=4#e131c16313154c4797d525a405cc8946)와 동일함을 확인했습니다.
{'rouge1': 36.3181, 'rouge2': 15.9132, 'rougeL': 27.0403, 'rougeLsum': 33.3804, 'gen_len': 19595, 'gen_num': 100}
- 추가로 full data set 확인을 위해 inference-compression 과 같이 data 를 나눠 돌리는 기능을 inference repo 기준으로 옮겨서 full dataset 결과 확인 예정입니다.