### PR TITLE
Calibration for GPT-J

### DIFF
--- a/ci_utils/check_qparam_equivalence.py
+++ b/ci_utils/check_qparam_equivalence.py
@@ -1,3 +1,4 @@
+import argparse
 def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--created_quant_param_path", help="path of the quant param file that is just created through calibrate.py")
@@ -47,9 +48,8 @@ def is_qparam_same(created_quant_param_path, released_quant_param_path, print_lo
     return True
 
 if __name__ == "__main__":
-    #args = get_args()
-    is_qparam_same('./qparam.npy', './quant_param.npy')
-    #print(is_qparam_same(args.created_quant_param_path, args.released_quant_param_path))
+    args = get_args()
+    print(is_qparam_same(args.created_quant_param_path, args.released_quant_param_path))
 
 
 

--- a/ci_utils/check_qparam_equivalence.py
+++ b/ci_utils/check_qparam_equivalence.py
@@ -10,7 +10,7 @@ def get_args():
 
 
 
-def is_qparam_same(created_quant_param_path, released_quant_param_path, print_log=True):
+def is_qparam_same(created_quant_param_path, released_quant_param_path, print_log=False):
     import numpy as np
 
 

--- a/ci_utils/check_qparam_equivalence.py
+++ b/ci_utils/check_qparam_equivalence.py
@@ -1,0 +1,59 @@
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--created_quant_param_path", help="path of the quant param file that is just created through calibrate.py")
+    parser.add_argument("--released_quant_param_path", help = "path of the quant param file that is released")
+
+
+    args = parser.parse_args()
+    return args
+
+
+
+def is_qparam_same(created_quant_param_path, released_quant_param_path, print_log=True):
+    import numpy as np
+
+
+    golden_qparam = np.load(created_quant_param_path, allow_pickle=True).item()
+    comparison_qparam = np.load(released_quant_param_path, allow_pickle=True).item()
+
+    failure_count = 0
+    for module_name, module_qparam in comparison_qparam.items():
+        try:
+            golden_data = golden_qparam[module_name]
+        except:
+            continue
+
+        for qparam_name, qparam in golden_data.items():
+            if qparam is None:
+                continue
+
+            if not np.array_equal(module_qparam[qparam_name], qparam):
+                failure_count = failure_count + 1
+                if print_log:
+                    print(
+                        "Failed ",
+                        module_name,
+                        qparam_name,
+                        (abs(module_qparam[qparam_name] - qparam) / abs(qparam)).max(),
+                    )
+            else:
+                if print_log:
+                    print("Passed ", module_name, qparam_name)
+
+    if failure_count != 0:
+        print(failure_count)
+        raise ValueError("Qparam comparision test failed.")
+
+    return True
+
+if __name__ == "__main__":
+    #args = get_args()
+    is_qparam_same('./qparam.npy', './quant_param.npy')
+    #print(is_qparam_same(args.created_quant_param_path, args.released_quant_param_path))
+
+
+
+
+
+
+

--- a/language/gpt-j/quantization/calibrate.py
+++ b/language/gpt-j/quantization/calibrate.py
@@ -6,8 +6,7 @@ import torch
 import yaml
 from torch.fx import GraphModule
 from torch.utils.data import DataLoader
-from transformers import AutoModelForCausalLM
-
+from transformers import AutoModelForCausalLM, AutoTokenizer
 import model_compressor  # isort:skip
 from dataset import Dataset  # isort:skip
 from quantization.utils import get_kwargs, random_seed, set_optimization  # isort:skip
@@ -31,7 +30,29 @@ def get_autoscale_calib_config(model_script, model, calib_dataloader):
 
 
 def load_pytorch_model(model_path, use_gpu):
-    model = AutoModelForCausalLM.from_pretrained(
+    from furiosa_llm_models.gptj.symbolic.huggingface_rope_rngd_gelu import GPTJForCausalLM
+    
+    model = GPTJForCausalLM.from_pretrained(
+        model_path,
+        device_map="auto" if not use_gpu else None,
+        low_cpu_mem_usage=True if not use_gpu else False,
+        torch_dtype=torch.float32,
+    )
+
+    if use_gpu:
+        print(f"Casting models to GPU...")
+        assert torch.cuda.is_available(), "torch gpu is not available, exiting..."
+        device = torch.device("cuda:0")
+        model.to(device)
+
+    model.eval()
+    model = model.to(memory_format=torch.channels_last)
+    return model
+
+def load_mlperf_submission_model(model_path, use_gpu):
+    from backend_RNGD import GPTJForCausalLM 
+    
+    model = GPTJForCausalLM.from_pretrained(
         model_path,
         device_map="auto" if not use_gpu else None,
         low_cpu_mem_usage=True if not use_gpu else False,
@@ -49,19 +70,70 @@ def load_pytorch_model(model_path, use_gpu):
     return model
 
 
-def cal_data_loader(calib_dataset_path, batch_size, n_calib):
+def make_calib_dataloader(calib_dataset_path, batch_size, n_calib):
     data_object = Dataset(calib_dataset_path, batch_size)
-    data_list = [
-        {
-            "input_ids": data_object.source_encoded_input_ids[idx],
-            "attention_mask": data_object.source_encoded_attn_masks[idx],
-            "position_ids": torch.arange(
-                len(data_object.source_encoded_input_ids[idx][0])
-            ),
-        }
-        for idx in range(len(data_object.source_encoded_input_ids))[:n_calib]
-    ]
+    data_list = []
+
+    for idx in range(n_calib):
+            bucket_size=2048
+            starting_input_ids = data_object.source_encoded_input_ids[idx]
+            batch_size, starting_input_len = starting_input_ids.shape
+            bucketized_input_ids = torch.zeros((batch_size, bucket_size), dtype=torch.int)
+            bucketized_input_ids[:, :starting_input_len] = starting_input_ids
+            
+            starting_attention_mask =  data_object.source_encoded_attn_masks[idx]
+            bucketized_attention_mask = torch.zeros((batch_size, bucket_size), dtype=torch.int)
+            bucketized_attention_mask[:, :starting_input_len] = starting_attention_mask
+            
+            starting_position_ids = torch.arange(len(data_object.source_encoded_input_ids[idx][0])).reshape(1,-1)
+            bucketized_position_ids = torch.cat([starting_position_ids, torch.zeros((1, bucket_size - starting_input_len), dtype=torch.long)], dim=1)
+            
+            data_list.append({'input_ids': bucketized_input_ids,
+                            'attention_mask': bucketized_attention_mask,
+                            'position_ids': bucketized_position_ids.squeeze(0)})
+    
     return DataLoader(data_list, batch_size)
+
+# def cal_data_loader(calib_dataset_path, model, batch_size, n_calib):
+#     GPTJ_MAX_LEN = 1919
+#     postprocess_func=None
+#     total_block_space=None
+#     max_length=None
+
+#     generator_class = "model_compressor.helper.QuantCausalLM"
+#     max_length=2048
+
+#     model_name_for_tokenizer = "EleutherAI/gpt-j-6B"
+
+#     calib_dataloader, _ = (
+#                 calib_generator(
+#                     calib_dataset_path,
+#                     model,
+#                     model_name_for_tokenizer,
+#                     generator_class,
+#                     AutoTokenizer,
+#                     device=model.device,
+#                     postprocess_func=postprocess_func,
+#                     model_max_length=GPTJ_MAX_LEN,
+#                     total_block_space=total_block_space,
+#                     max_length=max_length
+#                 )
+#             )
+
+
+
+#     data_object = Dataset(calib_dataset_path, batch_size)
+#     data_list = [
+#         {
+#             "input_ids": data_object.source_encoded_input_ids[idx],
+#             "attention_mask": data_object.source_encoded_attn_masks[idx],
+#             "position_ids": torch.arange(
+#                 len(data_object.source_encoded_input_ids[idx][0])
+#             ),
+#         }
+#         for idx in range(len(data_object.source_encoded_input_ids))[:n_calib]
+#     ]
+#     return DataLoader(data_list, batch_size)
 
 
 def calibrate(model: GraphModule, qconfig, qparam_path, qformat_path, calib_dataloader):
@@ -71,35 +143,77 @@ def calibrate(model: GraphModule, qconfig, qparam_path, qformat_path, calib_data
             qconfig, model, calib_dataloader
         )
 
-    model = model_compressor.create_quantsim_model(
-        model,
+    model_for_calib = model.trace_prefill()
+
+    model_for_calib = model_compressor.create_quantsim_model(
+        model_for_calib,
         dataloader=calib_dataloader,
-        disable_inout=(True, True),
+        disable_inout=(True, False),
         **get_kwargs(model_compressor.create_quantsim_model, qconfig),
     )
 
     model_compressor.calibrate(
-        model,
+        model_for_calib,
         calib_dataloader=calib_dataloader,
         autoscale_calib_kwargs=autoscale_calib_cfg if run_autoscale else None,
         **get_kwargs(model_compressor.calibrate, qconfig),
     )
 
     model_compressor.save(
-        model,
+        model_for_calib,
         qformat_out_path=qformat_path,
         qparam_out_path=qparam_path,
-        **get_kwargs(model_compressor.save, qconfig),
-    )
+        weight_calib_method=qconfig["weight_calib_method"],
+        weight_granularity=qconfig["weight_granularity"],
+        weight_dtype=qconfig["weight_dtype"],
+        weight_nbits=qconfig["weight_nbits"],
+        act_calib_method=qconfig["act_calib_method"],
+        act_granularity=qconfig["act_granularity"],
+        act_dtype=qconfig["act_dtype"],
+        act_nbits=qconfig["act_nbits"],
+        kv_dtype=qconfig["kv_dtype"] if  "kv_dtype" in qconfig else 'bf16',
+        disable_inout=(True, False),
+        )
+
+    del model_for_calib
 
     return
 
 
+def immigrate_qparams(model, golden_qparam_path, golden_qformat_path, quant_param_path, quant_format_path, qconfig):
+        
+        prefill_model = model_compressor.create_quantsim_model(
+            model.trace_prefill(),
+            qformat_path = golden_qformat_path,
+            qparam_path = golden_qparam_path,
+            qlevel=2,
+            target_machine=qconfig["target_machine"],
+            delete_org_weight=True,
+            immigrate_qparams = immigrate_qparams,
+        )
+
+        model_compressor.save(
+                prefill_model,
+                qparam_out_path=quant_param_path,
+                qformat_out_path=quant_format_path,
+                weight_calib_method=qconfig["weight_calib_method"],
+                weight_granularity=qconfig["weight_granularity"],
+                weight_dtype=qconfig["weight_dtype"],
+                weight_nbits=qconfig["weight_nbits"],
+                act_calib_method=qconfig["act_calib_method"],
+                act_granularity=qconfig["act_granularity"],
+                act_dtype=qconfig["act_dtype"],
+                act_nbits=qconfig["act_nbits"],
+                kv_dtype=qconfig["kv_dtype"] if  "kv_dtype" in qconfig else 'bf16',
+                disable_inout=(True, False),
+            )
+        
+        
+
+
 def get_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--backend", choices=["pytorch"], default="pytorch", help="Backend"
-    )
+
     parser.add_argument("--model_path", help="path to gpt-j model")
     parser.add_argument("--quant_config_path", help="a config for model quantization")
     parser.add_argument(
@@ -128,25 +242,27 @@ def get_args():
 def main():
     args = get_args()
     sut = None
-
-    if args.backend == "pytorch":
-        if not args.gpu:
-            raise ValueError(
-                "Inference on a device other than GPU is not supported yet."
-            )
-        model = load_pytorch_model(args.model_path, args.gpu)
-    else:
-        raise ValueError("Unsupported backend: {:}".format(args.backend))
+    #temp code for conveninet exp. will be removed
+    golden_model = load_pytorch_model(args.model_path, args.gpu)
 
     random_seed()
     set_optimization(args.torch_numeric_optim)
 
     with open(args.quant_config_path, "r") as f:
         qconfig = yaml.safe_load(f)
-    dataloader = cal_data_loader(
-        args.calib_data_path, qconfig["calib_batch_size"], args.n_calib
-    )
-    calibrate(model, qconfig, args.quant_param_path, args.quant_format_path, dataloader)
+        
+    dataloader = make_calib_dataloader(args.calib_data_path, qconfig["calib_batch_size"], args.n_calib)
+
+
+    golden_quant_param_path = args.quant_param_path.replace('.npy', '_golden.npy')
+    golden_quant_format_path = args.quant_format_path.replace('.yaml', '_golden.yaml')
+
+    calibrate(golden_model, qconfig, golden_quant_param_path, golden_quant_format_path, dataloader)
+    
+    submission_model = load_mlperf_submission_model(args.model_path, args.gpu)
+
+    immigrate_qparams(submission_model, golden_quant_param_path, golden_quant_format_path, args.quant_param_path, args.quant_format_path, qconfig)
+
 
 
 if __name__ == "__main__":

--- a/language/gpt-j/quantization/calibrate.py
+++ b/language/gpt-j/quantization/calibrate.py
@@ -94,47 +94,6 @@ def make_calib_dataloader(calib_dataset_path, batch_size, n_calib):
     
     return DataLoader(data_list, batch_size)
 
-# def cal_data_loader(calib_dataset_path, model, batch_size, n_calib):
-#     GPTJ_MAX_LEN = 1919
-#     postprocess_func=None
-#     total_block_space=None
-#     max_length=None
-
-#     generator_class = "model_compressor.helper.QuantCausalLM"
-#     max_length=2048
-
-#     model_name_for_tokenizer = "EleutherAI/gpt-j-6B"
-
-#     calib_dataloader, _ = (
-#                 calib_generator(
-#                     calib_dataset_path,
-#                     model,
-#                     model_name_for_tokenizer,
-#                     generator_class,
-#                     AutoTokenizer,
-#                     device=model.device,
-#                     postprocess_func=postprocess_func,
-#                     model_max_length=GPTJ_MAX_LEN,
-#                     total_block_space=total_block_space,
-#                     max_length=max_length
-#                 )
-#             )
-
-
-
-#     data_object = Dataset(calib_dataset_path, batch_size)
-#     data_list = [
-#         {
-#             "input_ids": data_object.source_encoded_input_ids[idx],
-#             "attention_mask": data_object.source_encoded_attn_masks[idx],
-#             "position_ids": torch.arange(
-#                 len(data_object.source_encoded_input_ids[idx][0])
-#             ),
-#         }
-#         for idx in range(len(data_object.source_encoded_input_ids))[:n_calib]
-#     ]
-#     return DataLoader(data_list, batch_size)
-
 
 def calibrate(model: GraphModule, qconfig, qparam_path, qformat_path, calib_dataloader):
     run_autoscale = qconfig.get("autoscale", "disabled") != "disabled"
@@ -242,7 +201,6 @@ def get_args():
 def main():
     args = get_args()
     sut = None
-    #temp code for conveninet exp. will be removed
     golden_model = load_pytorch_model(args.model_path, args.gpu)
 
     random_seed()

--- a/scripts/eval_qgpt-j_calib_test.sh
+++ b/scripts/eval_qgpt-j_calib_test.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# define env. variables
+model_name=qgpt-j
+model_dir=language/gpt-j
+git_dir=$(git rev-parse --show-toplevel)
+work_dir=$git_dir/$model_dir
+data_dir=$git_dir/data
+quant_data_dir=$data_dir/quantization/gpt-j
+log_dir=$git_dir/logs
+env_name=mlperf-$model_name-sunghyuck
+conda_base=$($CONDA_EXE info --base)
+
+# work on model directory
+cd $work_dir
+
+# enter existing conda env.
+source "$conda_base/etc/profile.d/conda.sh"
+conda activate $env_name
+
+# eval model
+printf "\n============= STEP-1: Run calibration =============\n"
+SCENARIO=${SCENARIO:="Offline"}
+#BACKEND="rngd"
+MODEL_TYPE="golden"
+MODEL_PATH=$data_dir/models/gpt-j
+DATASET_PATH=$data_dir/dataset/cnn-daily-mail/validation/cnn_eval.json
+LOG_PATH=$log_dir/$model_name/$SCENARIO/$(date +%Y%m%d_%H%M%S%Z)
+N_COUNT=${N_COUNT:="13368"} # total_len=13,368
+
+# quantization args
+export CALIBRATE=true
+N_CALIB=${N_CALIB:=1000} # total_len=1,000
+CALIB_DATA_PATH=$data_dir/dataset/cnn-daily-mail/calibration/cnn_dailymail_calibration.json
+QUANT_CONFIG_PATH=$quant_data_dir/quant_config.yaml
+QUANT_PARAM_PATH=$quant_data_dir/calibration_range/quant_param.npy
+QUANT_FORMAT_PATH=$quant_data_dir/calibration_range/quant_format.yaml
+
+printf "<<EVAL_CONFIG>>\n"
+printf "\tSCENARIO: $SCENARIO\n"
+printf "\tNUM_EVAL_DATA: $N_COUNT\n"
+printf "\tCALIBRATE: $CALIBRATE\n"
+
+export LOG_PATH
+
+mkdir -p $LOG_PATH/calibration_range
+
+if [ "$CALIBRATE" = true ]; then
+    printf "\t\tNUM_CALIB_DATA: $N_CALIB\n"
+    QUANT_PARAM_PATH=$LOG_PATH/calibration_range/quant_param.npy
+    QUANT_FORMAT_PATH=$LOG_PATH/calibration_range/quant_format.yaml
+    python -m quantization.calibrate --model_path=$MODEL_PATH \
+                                     --quant_config_path=$QUANT_CONFIG_PATH \
+                                     --quant_param_path=$QUANT_PARAM_PATH \
+                                     --quant_format_path=$QUANT_FORMAT_PATH \
+                                     --calib_data_path=$CALIB_DATA_PATH \
+                                     --n_calib=$N_CALIB \
+                                     --gpu
+    printf "Save calibration range to $LOG_PATH/calibration_range"
+else
+    cp $QUANT_PARAM_PATH $LOG_PATH/calibration_range/quant_param.npy
+    cp $QUANT_FORMAT_PATH $LOG_PATH/calibration_range/quant_format.yaml
+fi
+
+cd $git_dir
+
+RELEASED_PARAM_PATH=$git_dir/ci_utils/released_qparams/gpt-j/qparam.npy
+printf "\n============= STEP-2: Check the equivalence of quantiation parameters =============\n"
+
+python -m ./ci_utils/check_quantization_equivalence.py --released_quant_param_path=$RELEASED_PARAM_PATH \
+                                    --created_quant_param_path=$QUANT_PARAM_PATH\
+
+
+                                            
+
+
+
+
+
+
+
+unset LOG_PATH
+
+printf "\n============= End of calibration =============\n"
+
+# exit from conda env.
+conda deactivate
+
+# get back to git root
+cd $git_dir

--- a/scripts/qgpt-j_calib_test.sh
+++ b/scripts/qgpt-j_calib_test.sh
@@ -8,7 +8,7 @@ work_dir=$git_dir/$model_dir
 data_dir=$git_dir/data
 quant_data_dir=$data_dir/quantization/gpt-j
 log_dir=$git_dir/logs
-env_name=mlperf-$model_name-sunghyuck
+env_name=mlperf-$model_name
 conda_base=$($CONDA_EXE info --base)
 
 # work on model directory

--- a/scripts/qgpt-j_calib_test.sh
+++ b/scripts/qgpt-j_calib_test.sh
@@ -73,11 +73,6 @@ python ci_utils/check_qparam_equivalence.py --released_quant_param_path=$RELEASE
                                             
 
 
-
-
-
-
-
 unset LOG_PATH
 
 printf "\n============= End of calibration =============\n"

--- a/scripts/qgpt-j_calib_test.sh
+++ b/scripts/qgpt-j_calib_test.sh
@@ -46,7 +46,7 @@ export LOG_PATH
 mkdir -p $LOG_PATH/calibration_range
 
 if [ "$CALIBRATE" = true ]; then
-    printf "\t\tNUM_CALIB_DATA: $N_CALIB\n"
+    printf "\tNUM_CALIB_DATA: $N_CALIB\n"
     QUANT_PARAM_PATH=$LOG_PATH/calibration_range/quant_param.npy
     QUANT_FORMAT_PATH=$LOG_PATH/calibration_range/quant_format.yaml
     python -m quantization.calibrate --model_path=$MODEL_PATH \
@@ -63,7 +63,6 @@ else
 fi
 
 cd $git_dir
-
 RELEASED_PARAM_PATH=$git_dir/ci_utils/released_qparams/gpt-j/qparam.npy
 printf "\n============= STEP-2: Check the equivalence of quantiation parameters =============\n"
 

--- a/scripts/qgpt-j_calib_test.sh
+++ b/scripts/qgpt-j_calib_test.sh
@@ -67,9 +67,8 @@ cd $git_dir
 RELEASED_PARAM_PATH=$git_dir/ci_utils/released_qparams/gpt-j/qparam.npy
 printf "\n============= STEP-2: Check the equivalence of quantiation parameters =============\n"
 
-python -m ./ci_utils/check_quantization_equivalence.py --released_quant_param_path=$RELEASED_PARAM_PATH \
+python ci_utils/check_qparam_equivalence.py --released_quant_param_path=$RELEASED_PARAM_PATH \
                                     --created_quant_param_path=$QUANT_PARAM_PATH\
-
 
                                             
 


### PR DESCRIPTION
- Inference compression에서의 calibration code를 사용하도록 변경
- GPT-J calibration 기본 방침: huggingface_rope_rngd_gelu에서 custom dataloader를 바탕으로 calibration with padding을 수행하고, 해당 qparam을 immigrate 해서 사용 
- ci_utils에 이전 release에 공개 되었던 qparam 파일을 가지고 있고, scripts/qgpt-j_calib_test.sh를 실행할때 만들어진 qparam과 해당 qparam을 비교함 
- mcp의 코드 변경 사항이 qparam 동치를 보장하도록 하고, 제출할 qparam의 재현성을 보장함 