### PR TITLE
Update v3.13 gptj

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For evaluations with different settings, modify the following environment variab
 
 ### Wi8Ai8KVi8 Quantized GPT-J (qGPT-J)
 
-- Evaluation Result(v3.12.1)
+- Evaluation Result(v3.13)
 
     |         | Our Result                | Accuracy Target |
     |:-------:|:-------------------------:|:---------------:|
@@ -52,7 +52,6 @@ For evaluations with different settings, modify the following environment variab
     | ROUGEL  | 30.0211 (100.11%)         | [29.9881](https://github.com/mlcommons/inference/blob/e39003a9c4c89a2215db0ca57ad7a57b16f9a785/tools/submission/submission_checker.py#L1126C92-L1126C99) |
     | GEN_LEN | 3,978,315 (99.04%)        | [4,016,878](https://github.com/mlcommons/inference/blob/e39003a9c4c89a2215db0ca57ad7a57b16f9a785/tools/submission/submission_checker.py#L1126C120-L1126C127) |
     
-    - reference: [v3.11 Quantized GPT-J evaluation report](https://www.notion.so/furiosa/hugginface_rope_rngd_gelu-061729cc2bdc4410a9dd078fa05a317d)
 
 To reproduce the results, run the following commands:
 

--- a/data/quantization/gpt-j.dvc
+++ b/data/quantization/gpt-j.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: bdd4495238c41bbdc4115ab304760192.dir
-  size: 11608232
-  nfiles: 3
+- md5: e669e65f6f287986371bedf631b21453.dir
+  size: 522
+  nfiles: 1
   hash: md5
   path: gpt-j

--- a/logs/internal/qgpt-j.dvc
+++ b/logs/internal/qgpt-j.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 78406ddb57ab1dce9c2662aee03668dd.dir
-  size: 13855549105
-  nfiles: 9
+- md5: 396ed8c57357132ca2ec7a17803400e9.dir
+  size: 26842925
+  nfiles: 4
   hash: md5
   path: qgpt-j

--- a/scripts/build_qgpt-j_env.sh
+++ b/scripts/build_qgpt-j_env.sh
@@ -8,6 +8,9 @@ work_dir=$git_dir/$model_dir
 data_dir=$git_dir/data
 env_name=mlperf-$model_name
 conda_base=$($CONDA_EXE info --base)
+quant_data_dir=$data_dir/quantization/gpt-j
+tag=MLPerf4.1-v3.13
+quant_data_dvc_dir=quantized/GPT-J/mlperf_submission/W8A8KV8/28L
 
 # work on model directory
 cd $work_dir
@@ -34,6 +37,20 @@ pip install dvc[s3]
 dvc pull $data_dir/models/gpt-j --force
 dvc pull $data_dir/dataset/cnn-daily-mail --force
 dvc pull $data_dir/quantization/gpt-j --force
+
+# pull quantization 
+printf "\n============= STEP-4: Pull quantization data =============\n"
+cd $git_dir
+git clone https://github.com/furiosa-ai/furiosa-llm-models-artifacts.git
+cd $git_dir/furiosa-llm-models-artifacts
+git checkout $tag
+
+dvc pull $git_dir/furiosa-llm-models-artifacts/$quant_data_dvc_dir/qformat.yaml.dvc -r origin --force
+dvc pull $git_dir/furiosa-llm-models-artifacts/$quant_data_dvc_dir/qparam.npy.dvc -r origin --force
+
+mkdir -p $quant_data_dir/calibration_range
+cp $git_dir/furiosa-llm-models-artifacts/$quant_data_dvc_dir/qformat.yaml $quant_data_dir/calibration_range/quant_format.yaml
+cp $git_dir/furiosa-llm-models-artifacts/$quant_data_dvc_dir/qparam.npy $quant_data_dir/calibration_range/quant_param.npy
 
 printf "\n============= End of build =============\n"
 

--- a/scripts/build_qgpt-j_env.sh
+++ b/scripts/build_qgpt-j_env.sh
@@ -51,6 +51,7 @@ dvc pull $git_dir/furiosa-llm-models-artifacts/$quant_data_dvc_dir/qparam.npy.dv
 mkdir -p $quant_data_dir/calibration_range
 cp $git_dir/furiosa-llm-models-artifacts/$quant_data_dvc_dir/qformat.yaml $quant_data_dir/calibration_range/quant_format.yaml
 cp $git_dir/furiosa-llm-models-artifacts/$quant_data_dvc_dir/qparam.npy $quant_data_dir/calibration_range/quant_param.npy
+rm -rf $git_dir/furiosa-llm-models-artifacts
 
 printf "\n============= End of build =============\n"
 

--- a/scripts/envs/gpt-j_env.yml
+++ b/scripts/envs/gpt-j_env.yml
@@ -13,4 +13,4 @@ dependencies:
       - rouge_score==0.1.2
       - accelerate==0.31.0
       - numpy==1.26.4
-      - git+https://github.com/furiosa-ai/furiosa-llm-models.git@MLPerf4.1-v3.11
+      - git+https://github.com/furiosa-ai/furiosa-llm-models.git@MLPerf4.1-v3.13

--- a/scripts/envs/qgpt-j_env.yml
+++ b/scripts/envs/qgpt-j_env.yml
@@ -12,6 +12,6 @@ dependencies:
       - evaluate==0.4.1
       - absl-py==2.1.0
       - rouge_score==0.1.2
-      - git+https://github.com/furiosa-ai/furiosa-llm-models.git@MLPerf4.1-v3.12.1
-      - git+https://github.com/furiosa-ai/model-compressor-private.git@MLPerf4.1-v3.12.1
+      - git+https://github.com/furiosa-ai/furiosa-llm-models.git@MLPerf4.1-v3.13
+      - git+https://github.com/furiosa-ai/model-compressor-private.git@MLPerf4.1-v3.13
       - accelerate==0.31.0


### PR DESCRIPTION
GPT-J v3.13 update 반영

- GPT-J mlperf_submission model 은 [v3.13](https://furiosa-ai.slack.com/archives/C03PPKEGYUC/p1720799296007649) 에서 qformat, qparam 변경 없음, accuracy 변화 없음
- env 의 v3.12.1 -> v3.13 으로 변경
- quant_format, quant_param 을 furiosa-llm-models-artifacts 에서 (이전 https://github.com/furiosa-ai/inference/pull/31#issuecomment-2217692093) 가져오도록 수정함
    - data/quantization/gpt-j.dvc 에서 quant_format, quant_param 제외
    - scripts/build_qgpt-j_env.sh 동작 시 furiosa-llm-models-artifacts 에서 quant_format, quant_param 을 가져오도록 함
build_qgpt-j_env.sh 후에 100 sample 의 accuracy 확인, v3.12.1 과 동일함을 확인함
{'rouge1': 36.3181, 'rouge2': 15.9132, 'rougeL': 27.0403, 'rougeLsum': 33.3804, 'gen_len': 19595, 'gen_num': 100}

- logs/internal 에 full dataset 결과 update
   - #36 에서 추가한 multi gpu evaluation 을 통해 확인, accuracy results 및 log 파일 update
   - {'rouge1': 43.0305, 'rouge2': 20.1437, 'rougeL': 30.0211, 'rougeLsum': 40.186, 'gen_len': 3978315, 'gen_num': 13368}
   [v3.12 결과](https://www.notion.so/furiosa/MLPerf4-1-v3-12-5bebd974a1a04275b57209cb3bd3e9d8?pvs=4#5062fab8dd4a41f3bf1ba00ddc25b8d7)와 동일함을 확인 