### PR TITLE
Update llama v3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For evaluations with different settings, modify the following environment variab
 
 ### Wi8Ai8KVi8 Quantized LLaMA2 (qLLaMA2)
 
-- Evaluation Result(v3.11)
+- Evaluation Result(v3.13)
 
     |                   | Our Result |                                                                   Accuracy Target(99.9%)                                                                  |
     |:-----------------:|:----------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------:|

--- a/data/quantization/llama2-70b.dvc
+++ b/data/quantization/llama2-70b.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: a16adc861e07ee98b92f13302df860f5.dir
-  size: 79384835
-  nfiles: 3
+- md5: f0db64bd3009071aa95d6b7f3aa98a3f.dir
+  size: 419
+  nfiles: 1
   hash: md5
   path: llama2-70b

--- a/language/llama2-70b/RNGD_SUT.py
+++ b/language/llama2-70b/RNGD_SUT.py
@@ -64,7 +64,6 @@ class SUT(PyTorchSUT):
     ):
         self.quantize = args.quantize
         self.torch_numeric_optim = args.torch_numeric_optim
-        self.quant_config_path = args.quant_config_path
         self.quant_param_path = args.quant_param_path
         self.quant_format_path = args.quant_format_path
         super().__init__(
@@ -242,7 +241,6 @@ class SUT(PyTorchSUT):
             traced_model = self.model.trace_all()
             model = quantize_model(
                 traced_model,
-                qconfig_path=self.quant_config_path,
                 qparam_path=self.quant_param_path,
                 qformat_path=self.quant_format_path,
             )

--- a/language/llama2-70b/main.py
+++ b/language/llama2-70b/main.py
@@ -27,7 +27,6 @@ def get_args():
     parser.add_argument("--output-log-dir", type=str, default="output-logs", help="Where logs are saved")
     parser.add_argument("--enable-log-trace", action="store_true", help="Enable log tracing. This file can become quite large")
     parser.add_argument("--num-workers", type=int, default=1, help="Number of workers to process queries")
-    parser.add_argument("--quant_config_path", help="a config for model quantization")
     parser.add_argument("--quant_param_path", help="quantization parameters for calibrated layers")
     parser.add_argument("--quant_format_path", help="quantization specifications for calibrated layers")
     parser.add_argument("--quantize", action="store_true", help="quantize model using Model Compressor")

--- a/language/llama2-70b/quantization/quantize.py
+++ b/language/llama2-70b/quantization/quantize.py
@@ -6,10 +6,11 @@ from torch.fx import GraphModule
 import model_compressor  # isort:skip
 from .utils import get_kwargs  # isort:skip
 
+TARGET_MACHINE='RGDA0'
+QLEVEL=4
 
 def _quantize(
     model: GraphModule,
-    qconfig: Dict[str, Any],
     qparam_path: str,
     qformat_path: str,
     quantized_prefill: Optional[GraphModule] = None,
@@ -18,51 +19,45 @@ def _quantize(
         model,
         qformat_path=qformat_path,
         qparam_path=qparam_path,
-        disable_inout=(True, True),
         delete_org_weight=True,
         decode_phase=quantized_prefill is not None,
         quantized_prefill_model=quantized_prefill,
         # https://github.com/furiosa-ai/inference/pull/29/files#diff-9b228ac2c8c424039f8ab41443631c4097f3c3abf73a05b3e327c51ed30d394dR65
         # TODO: the original code uses fp32, but we use fp64 here for validation.
         weighted_op_emul_dtype="fp64",
-        **get_kwargs(model_compressor.create_quantsim_model, qconfig),
+        target_machine=TARGET_MACHINE,
+        qlevel=QLEVEL,
     )
 
 
 def quantize_prefill_graph(
-    model: GraphModule, qconfig: Dict[str, Any], qparam_path: str, qformat_path: str
+    model: GraphModule, qparam_path: str, qformat_path: str
 ) -> GraphModule:
-    return _quantize(model, qconfig, qparam_path, qformat_path)
+    return _quantize(model, qparam_path, qformat_path)
 
 
 def quantize_decode_graph(
     model: GraphModule,
-    qconfig: Dict[str, Any],
     qparam_path: str,
     qformat_path: str,
     quantized_prefill: GraphModule,
 ) -> GraphModule:
-    return _quantize(model, qconfig, qparam_path, qformat_path, quantized_prefill)
+    return _quantize(model, qparam_path, qformat_path, quantized_prefill)
 
 
 def quantize_model(
     model: Dict[str, GraphModule],
-    qconfig_path: str,
     qparam_path: str,
     qformat_path: str,
 ) -> Dict[str, GraphModule]:
-    with open(qconfig_path, "r") as f:
-        qconfig = yaml.safe_load(f)
 
     quantized_prefill = quantize_prefill_graph(
         model=model["prefill"],
-        qconfig=qconfig,
         qparam_path=qparam_path,
         qformat_path=qformat_path,
     )
     quantized_decode = quantize_decode_graph(
         model=model["decode"],
-        qconfig=qconfig,
         qparam_path=qparam_path,
         qformat_path=qformat_path,
         quantized_prefill=quantized_prefill,

--- a/scripts/build_qllama2-70b_env.sh
+++ b/scripts/build_qllama2-70b_env.sh
@@ -8,6 +8,9 @@ work_dir=$git_dir/$model_dir
 data_dir=$git_dir/data
 env_name=mlperf-$model_name
 conda_base=$($CONDA_EXE info --base)
+quant_data_dir=$data_dir/quantization/llama2-70b
+tag=MLPerf4.1-v3.13
+quant_data_dvc_dir=quantized/LLaMA2-70B/mlperf_submission/W8A8KV8/80L
 
 # work on model directory
 cd $work_dir
@@ -40,6 +43,22 @@ dvc pull $data_dir/models/llama2/Llama-2-70b-chat-hf/!(model-000*|pytorch_model-
 dvc pull $data_dir/dataset/open-orca/validation --force
 dvc pull $data_dir/dataset/open-orca/calibration --force
 dvc pull $data_dir/quantization/llama2-70b.dvc --force
+
+# pull quantization 
+printf "\n============= STEP-4: Pull quantization data =============\n"
+cd $git_dir
+git clone https://github.com/furiosa-ai/furiosa-llm-models-artifacts.git
+cd $git_dir/furiosa-llm-models-artifacts
+git checkout $tag
+
+dvc pull $git_dir/furiosa-llm-models-artifacts/$quant_data_dvc_dir/qformat.yaml.dvc -r origin --force
+dvc pull $git_dir/furiosa-llm-models-artifacts/$quant_data_dvc_dir/qparam.npy.dvc -r origin --force
+
+mkdir -p $quant_data_dir/calibration_range
+cp $git_dir/furiosa-llm-models-artifacts/$quant_data_dvc_dir/qformat.yaml $quant_data_dir/calibration_range/quant_format.yaml
+cp $git_dir/furiosa-llm-models-artifacts/$quant_data_dvc_dir/qparam.npy $quant_data_dir/calibration_range/quant_param.npy
+
+
 
 printf "\n============= End of build =============\n"
 

--- a/scripts/envs/llama2-70b_env.yml
+++ b/scripts/envs/llama2-70b_env.yml
@@ -15,4 +15,4 @@ dependencies:
       - nltk==3.8.1
       - absl-py==1.4.0
       - rouge-score==0.1.2
-      - git+https://github.com/furiosa-ai/furiosa-llm-models.git@MLPerf4.1-v3.11
+      - git+https://github.com/furiosa-ai/furiosa-llm-models.git@MLPerf4.1-v3.13

--- a/scripts/envs/qllama2-70b_env.yml
+++ b/scripts/envs/qllama2-70b_env.yml
@@ -16,5 +16,5 @@ dependencies:
       - nltk==3.8.1
       - absl-py==1.4.0
       - rouge-score==0.1.2
-      - git+https://github.com/furiosa-ai/furiosa-llm-models.git@MLPerf4.1-v3.11
-      - git+https://github.com/furiosa-ai/model-compressor-private.git@MLPerf4.1-v3.11
+      - git+https://github.com/furiosa-ai/furiosa-llm-models.git@MLPerf4.1-v3.13
+      - git+https://github.com/furiosa-ai/model-compressor-private.git@MLPerf4.1-v3.13

--- a/scripts/eval_qllama2-70b.sh
+++ b/scripts/eval_qllama2-70b.sh
@@ -77,7 +77,6 @@ python -u main.py --scenario $SCENARIO \
                   --accuracy \
                   --output-log-dir $LOG_PATH \
                   --quantize \
-                  --quant_config_path $QUANT_CONFIG_PATH \
                   --quant_param_path $QUANT_PARAM_PATH \
                   --quant_format_path $QUANT_FORMAT_PATH
 


### PR DESCRIPTION
LLaMA2-70B v3.12 + v3.13 update 반영

- v3.12 반영 사항
    - bert, gptj 와 동일하게 evaluation 할 때는 quant config 을 입력받을 필요가 없어 제외함
- v3.13 반영 사항  
    - llama2-70b 는 [v3.13](https://furiosa-ai.slack.com/archives/C03PPKEGYUC/p1720799296007649) 에서 smooth quant 적용으로 qformat, qparam 변경 있음, accuracy 변화 있음
    - quant_config 업데이트 (evaluation 에 사용되진 않지만 calibration 에 사용하기 위해 업데이트)
    - env 의 v3.12.1 -> v3.13 으로 변경
    - quant_format, quant_param 을 furiosa-llm-models-artifacts 에서 (이전 https://github.com/furiosa-ai/inference/pull/31#issuecomment-2217692093) 가져오도록 수정함
        - data/quantization/llama2-70b.dvc 에서 quant_format, quant_param 제외
        - scripts/build_qllama2-70b_env.sh 동작 시 furiosa-llm-models-artifacts 에서 quant_format, quant_param 을 가져오도록 함
- inference-compression v3.13 에서 fp64 로 확인한 golden model 10 sample accuracy 와 해당 PR 에서의 mlperf_submission model 10 sample accuracy가 동일함을 확인함
{'rouge1': 50.2007, 'rouge2': 24.4978, 'rougeL': 29.5546, 'rougeLsum': 47.6315, 'gen_len': 11510, 'gen_num': 10, 'gen_tok_len': 2771, 'tokens_per_sample': 277.1}
