### PR TITLE
Fix gpt-j ci test

### DIFF
--- a/ci_scripts/qgpt-j-forward_test.sh
+++ b/ci_scripts/qgpt-j-forward_test.sh
@@ -88,6 +88,9 @@ python -m ci_file.qgpt_j_forward_test          --model_path=$MODEL_PATH \
 
 
 unset LOG_PATH
+unset CALIBRATE
+unset N_CALIB
+unset N_DATA
 
 printf "\n============= End of Forward Test for QGPT-J =============\n"
 

--- a/ci_scripts/qgpt-j_calib_test.sh
+++ b/ci_scripts/qgpt-j_calib_test.sh
@@ -10,6 +10,26 @@ quant_data_dir=$data_dir/quantization/gpt-j
 log_dir=$git_dir/logs
 env_name=mlperf-$model_name
 conda_base=$($CONDA_EXE info --base)
+tag=MLPerf4.1-v3.13
+quant_data_dvc_dir=quantized/GPT-J/mlperf_submission/W8A8KV8/28L
+
+printf "\n============= STEP-1: Pull dvc data =============\n"
+cd $git_dir
+git clone https://github.com/furiosa-ai/furiosa-llm-models-artifacts.git
+cd $git_dir/furiosa-llm-models-artifacts
+git checkout $tag
+
+dvc pull $git_dir/furiosa-llm-models-artifacts/$quant_data_dvc_dir/qformat.yaml.dvc -r origin --force
+dvc pull $git_dir/furiosa-llm-models-artifacts/$quant_data_dvc_dir/qparam.npy.dvc -r origin --force
+
+mkdir -p $quant_data_dir/calibration_range
+cp $git_dir/furiosa-llm-models-artifacts/$quant_data_dvc_dir/qformat.yaml $quant_data_dir/calibration_range/quant_format.yaml
+cp $git_dir/furiosa-llm-models-artifacts/$quant_data_dvc_dir/qparam.npy $quant_data_dir/calibration_range/quant_param.npy
+rm -rf $git_dir/furiosa-llm-models-artifacts
+
+
+RELEASED_PARAM_PATH=$quant_data_dir/calibration_range/quant_param.npy
+
 
 # work on model directory
 cd $work_dir
@@ -19,7 +39,7 @@ source "$conda_base/etc/profile.d/conda.sh"
 conda activate $env_name
 
 # eval model
-printf "\n============= STEP-1: Run calibration =============\n"
+printf "\n============= STEP-2: Run calibration =============\n"
 SCENARIO=${SCENARIO:="Offline"}
 #BACKEND="rngd"
 MODEL_TYPE="golden"
@@ -36,7 +56,7 @@ QUANT_CONFIG_PATH=$quant_data_dir/quant_config.yaml
 QUANT_PARAM_PATH=$quant_data_dir/calibration_range/quant_param.npy
 QUANT_FORMAT_PATH=$quant_data_dir/calibration_range/quant_format.yaml
 
-printf "<<EVAL_CONFIG>>\n"
+printf "<<CALIB_CONFIG>>\n"
 printf "\tSCENARIO: $SCENARIO\n"
 printf "\tNUM_EVAL_DATA: $N_COUNT\n"
 printf "\tCALIBRATE: $CALIBRATE\n"
@@ -63,10 +83,7 @@ else
 fi
 
 
-printf "\n============= STEP-2: Pull dvc data =============\n"
-pip install dvc[s3]
-dvc pull --force $data_dir/quantization/gpt-j.dvc
-RELEASED_PARAM_PATH=$data_dir/quantization/gpt-j/calibration_range/quant_param.npy
+
 
 
 printf "\n============= STEP-3: Check the equivalence of quantiation parameters =============\n"

--- a/ci_scripts/qgpt-j_calib_test.sh
+++ b/ci_scripts/qgpt-j_calib_test.sh
@@ -78,6 +78,7 @@ python ci_file/utils/check_qparam_equivalence.py --released_quant_param_path=$RE
 
 
 unset LOG_PATH
+unset CALIBRATE
 
 printf "\n============= End of calibration =============\n"
 

--- a/ci_scripts/qgpt-j_calib_test.sh
+++ b/ci_scripts/qgpt-j_calib_test.sh
@@ -75,7 +75,8 @@ if [ "$CALIBRATE" = true ]; then
                                      --quant_format_path=$QUANT_FORMAT_PATH \
                                      --calib_data_path=$CALIB_DATA_PATH \
                                      --n_calib=$N_CALIB \
-                                     --gpu
+                                     --gpu \
+                                     --save_cache_files
     printf "Save calibration range to $LOG_PATH/calibration_range"
 else
     cp $QUANT_PARAM_PATH $LOG_PATH/calibration_range/quant_param.npy

--- a/language/gpt-j/ci_file/utils/check_qparam_equivalence.py
+++ b/language/gpt-j/ci_file/utils/check_qparam_equivalence.py
@@ -50,7 +50,7 @@ def is_qparam_same(created_quant_param_path, released_quant_param_path, print_lo
 if __name__ == "__main__":
     args = get_args()
     if is_qparam_same(args.created_quant_param_path, args.released_quant_param_path):
-        print("The Quantiation parameter comparsion test is passed.")
+        print("The Quantization parameter comparsion test is passed.")
 
 
 

--- a/language/gpt-j/quantization/calibrate.py
+++ b/language/gpt-j/quantization/calibrate.py
@@ -10,6 +10,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 import model_compressor  # isort:skip
 from dataset import Dataset  # isort:skip
 from quantization.utils import get_kwargs, random_seed, set_optimization  # isort:skip
+from quantization.quantize import quantize_model
 
 
 def get_autoscale_calib_config(model_script, model, calib_dataloader):
@@ -95,7 +96,7 @@ def make_calib_dataloader(calib_dataset_path, batch_size, n_calib):
     return DataLoader(data_list, batch_size)
 
 
-def calibrate(model: GraphModule, qconfig, qparam_path, qformat_path, calib_dataloader):
+def calibrate(model: GraphModule, model_type, qconfig, qparam_path, qformat_path, calib_dataloader, save_cache_files):
     run_autoscale = qconfig.get("autoscale", "disabled") != "disabled"
     if run_autoscale:
         autoscale_calib_cfg = get_autoscale_calib_config(
@@ -115,6 +116,7 @@ def calibrate(model: GraphModule, qconfig, qparam_path, qformat_path, calib_data
         model_for_calib,
         calib_dataloader=calib_dataloader,
         autoscale_calib_kwargs=autoscale_calib_cfg if run_autoscale else None,
+        model_type=model_type,
         **get_kwargs(model_compressor.calibrate, qconfig),
     )
 
@@ -133,6 +135,20 @@ def calibrate(model: GraphModule, qconfig, qparam_path, qformat_path, calib_data
         kv_dtype=qconfig["kv_dtype"] if  "kv_dtype" in qconfig else 'bf16',
         disable_inout=(True, False),
         )
+    
+    if save_cache_files:
+
+        traced_models = model.trace_all()
+        quant_models = quantize_model(traced_models, qparam_path, qformat_path,)
+
+        qlv4_prefill_out_path = qparam_path.replace("quant_param.npy", "prefill.bin")
+        qlv4_decode_out_path = qparam_path.replace("quant_param.npy", "decode.bin")
+        rblock_json_out_path = qparam_path.replace("quant_param.npy", "graph_patterns.json")
+
+        torch.save(quant_models["prefill"].state_dict(), qlv4_prefill_out_path)
+        torch.save(quant_models["decode"].state_dict(), qlv4_decode_out_path)
+        model_compressor.save_graph_patterns(model, rblock_json_out_path)      
+
 
     del model_for_calib
 
@@ -193,6 +209,12 @@ def get_args():
     parser.add_argument(
         "--gpu", action="store_true", help="use GPU instead of CPU for the inference"
     )
+    parser.add_argument(
+        "--save_cache_files",
+        action="store_true",
+        default=False,
+        help="if true qlv4 state_dict and rblock .json will be saved",
+    )
 
     args = parser.parse_args()
     return args
@@ -202,6 +224,8 @@ def main():
     args = get_args()
     sut = None
     golden_model = load_pytorch_model(args.model_path, args.gpu)
+
+    model_type = type(golden_model)
 
     random_seed()
     set_optimization(args.torch_numeric_optim)
@@ -215,7 +239,7 @@ def main():
     golden_quant_param_path = args.quant_param_path.replace('.npy', '_golden.npy')
     golden_quant_format_path = args.quant_format_path.replace('.yaml', '_golden.yaml')
 
-    calibrate(golden_model, qconfig, golden_quant_param_path, golden_quant_format_path, dataloader)
+    calibrate(golden_model, model_type, qconfig, golden_quant_param_path, golden_quant_format_path, dataloader, args.save_cache_files)
     
     submission_model = load_mlperf_submission_model(args.model_path, args.gpu)
 

--- a/language/gpt-j/quantization/calibrate.py
+++ b/language/gpt-j/quantization/calibrate.py
@@ -141,13 +141,15 @@ def calibrate(model: GraphModule, model_type, qconfig, qparam_path, qformat_path
         traced_models = model.trace_all()
         quant_models = quantize_model(traced_models, qparam_path, qformat_path,)
 
-        qlv4_prefill_out_path = qparam_path.replace("quant_param.npy", "prefill.bin")
-        qlv4_decode_out_path = qparam_path.replace("quant_param.npy", "decode.bin")
-        rblock_json_out_path = qparam_path.replace("quant_param.npy", "graph_patterns.json")
+        qlv4_prefill_out_path = qparam_path.replace("quant_param_golden.npy", "prefill.bin")
+        qlv4_decode_out_path = qparam_path.replace("quant_param_golden.npy", "decode.bin")
+        prefill_rblock_json_out_path = qparam_path.replace("quant_param_golden.npy", "prefill_graph_patterns.json")
+        decode_rblock_json_out_path = qparam_path.replace("quant_param_golden.npy", "decode_graph_patterns.json")
 
         torch.save(quant_models["prefill"].state_dict(), qlv4_prefill_out_path)
         torch.save(quant_models["decode"].state_dict(), qlv4_decode_out_path)
-        model_compressor.save_graph_patterns(model, rblock_json_out_path)      
+        model_compressor.save_graph_patterns(quant_models["prefill"], prefill_rblock_json_out_path)
+        model_compressor.save_graph_patterns(quant_models["decode"], decode_rblock_json_out_path)
 
 
     del model_for_calib

--- a/scripts/calibrate_qgpt-j.sh
+++ b/scripts/calibrate_qgpt-j.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# define env. variables
+model_name=qgpt-j
+model_dir=language/gpt-j
+git_dir=$(git rev-parse --show-toplevel)
+work_dir=$git_dir/$model_dir
+data_dir=$git_dir/data
+quant_data_dir=$data_dir/quantization/gpt-j
+log_dir=$git_dir/logs
+env_name=mlperf-$model_name
+conda_base=$($CONDA_EXE info --base)
+
+# work on model directory
+cd $work_dir
+
+# enter existing conda env.
+source "$conda_base/etc/profile.d/conda.sh"
+conda activate $env_name
+
+# eval model
+printf "\n============= STEP-1: Run calibration =============\n"
+SCENARIO=${SCENARIO:="Offline"}
+#BACKEND="rngd"
+MODEL_TYPE="golden"
+MODEL_PATH=$data_dir/models/gpt-j
+DATASET_PATH=$data_dir/dataset/cnn-daily-mail/validation/cnn_eval.json
+LOG_PATH=$log_dir/$model_name/$SCENARIO/$(date +%Y%m%d_%H%M%S%Z)
+N_COUNT=${N_COUNT:="13368"} # total_len=13,368
+
+# quantization args
+N_CALIB=${N_CALIB:=1000} # total_len=1,000
+CALIB_DATA_PATH=$data_dir/dataset/cnn-daily-mail/calibration/cnn_dailymail_calibration.json
+QUANT_CONFIG_PATH=$quant_data_dir/quant_config.yaml
+QUANT_PARAM_PATH=$quant_data_dir/calibration_range/quant_param.npy
+QUANT_FORMAT_PATH=$quant_data_dir/calibration_range/quant_format.yaml
+
+printf "<<CALIB_CONFIG>>\n"
+printf "\tSCENARIO: $SCENARIO\n"
+printf "\tCALIBRATE: $CALIBRATE\n"
+
+export LOG_PATH
+
+mkdir -p $LOG_PATH/calibration_range
+
+printf "\tNUM_CALIB_DATA: $N_CALIB\n"
+QUANT_PARAM_PATH=$LOG_PATH/calibration_range/quant_param.npy
+QUANT_FORMAT_PATH=$LOG_PATH/calibration_range/quant_format.yaml
+python -m quantization.calibrate --model_path=$MODEL_PATH \
+                                    --quant_config_path=$QUANT_CONFIG_PATH \
+                                    --quant_param_path=$QUANT_PARAM_PATH \
+                                    --quant_format_path=$QUANT_FORMAT_PATH \
+                                    --calib_data_path=$CALIB_DATA_PATH \
+                                    --n_calib=$N_CALIB \
+                                    --gpu
+printf "Save calibration range to $LOG_PATH/calibration_range"
+
+                                            
+
+
+unset LOG_PATH
+unset CALIBRATE
+
+printf "\n============= End of calibration =============\n"
+
+# exit from conda env.
+conda deactivate
+
+# get back to git root
+cd $git_dir


### PR DESCRIPTION
- GPT-J ci test 수정
   - export된 variable을 unset 해서 test 안전성 보장
    - GPT-J calibration 용 script 추가
    - released qparam을 furiosa-llm-models-artifacts의 dvc file로부터 pull하도록 수정 (아직 merge되지 않은 https://github.com/furiosa-ai/inference/pull/44의 gptj dvc pull 부분 반영)
    
- TEST
   - qgpt-j foward ci test (passed)
   - qgpt-j calib ci test (passed)