### PR TITLE
fix dump error

### DIFF
--- a/language/bert/RNGD_SUT.py
+++ b/language/bert/RNGD_SUT.py
@@ -60,9 +60,10 @@ class BERT_RNGD_SUT(BERT_PyTorch_SUT):
         self.version = transformers.__version__
 
         self.dump_path = args.dump_path
-        if not self.dump_path.exists():
-            with open(self.dump_path, "w") as f:
-                json.dump([], f)
+        if self.dump_path is not None:
+            if not self.dump_path.exists():
+                with open(self.dump_path, "w") as f:
+                    json.dump([], f)
         self.dump = {}
 
         print("Loading PyTorch model...")

--- a/scripts/eval_qbert.sh
+++ b/scripts/eval_qbert.sh
@@ -55,15 +55,16 @@ mkdir -p $LOG_PATH
 
 SECONDS=0
 python $work_dir/run.py --scenario=$SCENARIO \
-              --backend=$BACKEND \
-              --mlperf_conf=$MLPERF_CONF \
-              --gpu \
-              --quantize \
-              --quant_param_path=$QUANT_PARAM_PATH \
-              --quant_format_path=$QUANT_FORMAT_PATH \
-              --max_examples=$N_COUNT \
-              --accuracy \
-              --dump_path=$DUMP_PATH
+          --backend=$BACKEND \
+          --mlperf_conf=$MLPERF_CONF \
+          --gpu \
+          --quantize \
+          --quant_param_path=$QUANT_PARAM_PATH \
+          --quant_format_path=$QUANT_FORMAT_PATH \
+          --max_examples=$N_COUNT \
+          --accuracy \
+          $(if [ "$DO_DUMP" = "true" ]; then echo "--dump_path=$DUMP_PATH"; fi)
+          
 duration=$SECONDS
 printf "$((duration / 60)) minutes and $((duration % 60)) seconds elapsed." &> $LOG_PATH/elapsed_time.log
 


### PR DESCRIPTION
- BERT input/out dump PR #46 merge 이후에 eval_qbert.sh 실행 시 오류 발생
- DUMP_PATH 가 [none](https://github.com/furiosa-ai/inference/compare/v4.1-internal...BeomGeunCho:inference:fix_dump_bert?expand=1#diff-3e96a7a17f7f9ee2bd06d5e7a32c6cf0987628cda50bb44996c61e3f04d5a3afL28) 으로 입력 시 Path('none') 형태로 입력되기 때문에 구별이 어려움, DO_DUMP true 일 때만 dump_path 입력하도록 수정
- dump_path 를 입력하지 않아 default 값인 None 일 때 예외처리하는 코드 추가
- 해당 PR 과 같이 수정해서 eval_qbert.sh 실행시켜 v3.13.2 update version full test 결과 확인함